### PR TITLE
Release/6.3.0

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -1,20 +1,22 @@
 name: Testing
 
-on: [push]
+on: [ push ]
 
 jobs:
   unitTests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
       - name: Run unit tests
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :lib:testDebugUnitTest
+        run: ./gradlew :lib:testDebugUnitTest

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,14 +3,12 @@ minSdk = "21"
 compileSdk = "34"
 targetSdk = "34"
 kotlin = "1.9.10"
-gradlePlugin = "8.2.2"
-survicateSdk = "6.0.0"
-segmentAnalytics = "1.14.2"
-appcompat = "1.6.1"
-constraintlayout = "2.1.4"
-coreKtx = "1.12.0"
-serializationJson = "1.6.0"
-material = "1.11.0"
+gradlePlugin = "8.10.0"
+survicateSdk = "6.3.0"
+segmentAnalytics = "1.19.2"
+appcompat = "1.7.0"
+material = "1.12.0"
+serializationJson = "1.6.3"
 dokkaPlugin = "1.9.10"
 junitBom = "5.10.0"
 junit = "4.13.2"
@@ -26,8 +24,6 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokkaPlugin" }
 
 [libraries]
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serializationJson" }
 material = { module = "com.google.android.material:material", version.ref = "material" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     `maven-publish`
 }
 
-ext.set("lib_version", "6.0.0")
+ext.set("lib_version", "6.3.0")
 
 android {
     namespace = "com.segment.analytics.kotlin.destinations.survicate"

--- a/lib/s3.publish.gradle
+++ b/lib/s3.publish.gradle
@@ -1,12 +1,9 @@
 /**
  * Steps to publish:
- * 1. Make sure that you have a valid s3.maven.properties file (it is not committed to git,
- *    use s3.maven.properties.demo as a template)
- * 2. Bump lib_version inside the build.gradle of the lib module.
- * 3. Call ./gradlew :lib:cleanBuildDocPublish in order to make sure it builds correctly (and get rid of
- *    possible errors) and next upload to s3 repo.
+ * 1. Bump lib_version inside the build.gradle of the lib module.
+ * 2. Publish the SDK locally to test the artifact build process: ./gradlew :lib:cleanBuildDocPublishLocal
+ * 3. Publish to Survicate Maven by running the "Publish SDK" workflow.
  */
-
 tasks.register('androidJavadocsJar', Jar) {
     dependsOn dokkaJavadoc
     archiveClassifier.set('javadoc')

--- a/testapp/build.gradle.kts
+++ b/testapp/build.gradle.kts
@@ -50,9 +50,6 @@ android {
 dependencies {
     implementation(project(mapOf("path" to ":lib")))
     implementation(libs.segment.analytics)
-
-    implementation(libs.core.ktx)
     implementation(libs.appcompat)
     implementation(libs.material)
-    implementation(libs.constraintlayout)
 }

--- a/testapp/build.gradle.kts
+++ b/testapp/build.gradle.kts
@@ -1,4 +1,3 @@
-import groovy.lang.MissingPropertyException
 import java.util.Properties
 
 plugins {

--- a/testapp/src/main/java/com/segment/analytics/destinations/survicate/testapp/MainActivity.kt
+++ b/testapp/src/main/java/com/segment/analytics/destinations/survicate/testapp/MainActivity.kt
@@ -34,7 +34,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun setupEventTypeSpinner() {
-        val eventTypes = TestEventType.values()
+        val eventTypes = TestEventType.entries.toTypedArray()
         spinnerEventType.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, eventTypes)
     }
 


### PR DESCRIPTION
- Bumped Survicate SDK version to 6.3.0.
- Bumped Plugin version to 6.3.0 (in sync).
- Updated AGP and dependencies.
- Removed unused test app dependencies.
- Updated build instruction and GH testing workflow.

<img src="https://github.com/user-attachments/assets/c4a2af4a-75f8-4889-8ccf-9421495a0d92" width="50%" />
